### PR TITLE
Add hyphen draft ADR for workflow test

### DIFF
--- a/docs/architecture-decision-records/application/testing/hyphen-status-draft-adr.md
+++ b/docs/architecture-decision-records/application/testing/hyphen-status-draft-adr.md
@@ -1,0 +1,55 @@
+# [Number]: Hyphen Draft Status ADR
+
+{
+    Update [Title] but leave [Number] untouched as the auto-index-docs workflow will update it for you!
+}
+
+## Status - Draft
+
+## CONTEXT
+
+{
+Describe the issue that necessitated this decision, including any
+relevant factors or constraints.
+}
+
+### Considered Options
+
+{
+List the options that were considered.
+ * Option 1
+ * Option 2
+}
+
+## DECISION
+
+{
+Detail the decision that was made, including any alternatives that were
+considered and why they were not chosen.
+}
+
+## CONSEQUENCES
+
+{
+Discuss the implications of this decision, including positive and negative
+outcomes, and how it will affect the current and future architecture.
+}
+
+### Risks
+
+{
+List any risks that may arise from this decision.
+}
+
+
+## NOTES
+
+### References
+
+### Original Author
+
+### Approval date
+
+### Approved by
+
+## Appendix


### PR DESCRIPTION
## Summary
- add a hyphenated status ADR fixture that uses a non-exception status
- ensures the auto-index workflow must normalize both the heading format and status value

## Testing
- none